### PR TITLE
Update to meet HELICS licensing plan and recommended open source community standards

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at helicsteam@helics.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+what is the current behavior
+
+**What is the expected behavior?**
+ What is the motivation / use case for changing the behavior?
+
+**To Reproduce**
+Steps to reproduce the behavior:
+Please provide a minimal working example of the bug if possible.
+
+**Environment (please complete the following information):**
+ - Operating System: [all | Windows | Mac | Linux | BSD]
+ - What compiler or setup process did you use?
+ - Which version/commit of the library did you use?
+
+**Additional context and information**
+(e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support-or-design-question.md
+++ b/.github/ISSUE_TEMPLATE/support-or-design-question.md
@@ -1,0 +1,7 @@
+---
+name: Support or design question
+about: Ask a detailed question or start a design discussion
+
+---
+
+Please describe the question and desired information in detail, or discuss the nature of the question being asked.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
+Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
+Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
+e.g. This fixes issue #123-->
+
+### Summary
+
+<!-- please finish the following statement -->
+If merged this pull request will
+
+### Proposed changes
+
+<!-- Describe the highlights of the proposed changes here -->
+-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Copyright (c) 2019, Battelle Memorial Institute; Lawrence Livermore
+# National Security, LLC; Alliance for Sustainable Energy, LLC.
+# See the top-level NOTICE for additional details.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 cmake_minimum_required(VERSION 3.4)
 project("NetIF")
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following is a set of guidelines for contributing to HELICS and associated p
 ## Table Of Contents
 
 ## Licensing
-HELICS is distributed under the terms of the BSD-3 clause license. All new
+HELICS and GMLC-TDC/netif are distributed under the terms of the BSD-3 clause license. All new
 contributions must be made under this [LICENSE](LICENSE) in accordance with the Github [terms of service](https://help.github.com/en/articles/github-terms-of-service#6-contributions-under-repository-license), which uses inbound=outbound policy.  By submitting a pull request you are acknowledging that you have the right to license your code under these terms.
 
 If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to HELICS and the GMLC-TDC archives
+
+:+1: First off, thank you for taking the time to contribute! :+1:
+
+The following is a set of guidelines for contributing to HELICS and associated projects. These are suggested guidelines. Use your best judgment.
+
+## Table Of Contents
+
+## Licensing
+HELICS is distributed under the terms of the BSD-3 clause license. All new
+contributions must be made under this [LICENSE](LICENSE) in accordance with the Github [terms of service](https://help.github.com/en/articles/github-terms-of-service#6-contributions-under-repository-license), which uses inbound=outbound policy.  By submitting a pull request you are acknowledging that you have the right to license your code under these terms.
+
+If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
+
+## How Can I Contribute
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for the NetIF library. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
+
+When you are creating a bug report, please include as many details as possible.  Frequently, helpful information includes operating system, version, compiler used, API, interface, and some details about the function or operation being performed.
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+### Submitting a pull request
+Typically you would want to submit a pull request against the develop branch.  That branch gets merged into master periodically but the develop branch is the active development branch where all the code is tested and merged before making a release.  There is a [Pull request template](.github/PULL_REQUEST_TEMPLATE.md) that will guide you through the needed information. 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+# Contributors
+This file describes the contributors to the NetIF library and the software used as part of this project. It is part of the GMLC-TDC project and used in the HELICS project.  HELICS is a joint project between PNNL, LLNL, and NREL, with contributions from many other national Labs
+If you would like to contribute to the NetIF, HELICS or any of the GMLC-TDC related repositories see [CONTRIBUTING](CONTRIBUTING.md)
+
+## Individual contributors
+
+### Lawrence Livermore National Lab
+ - Philip Top
+ - Ryan Mast`
+
+### National Renewable Energy Lab
+ - Dheepak Krishnamurthy
+
+## Used Libraries or Code
+
+### [HELICS](https://github.com/GMLC-TDC/HELICS)  
+Most of the original code for this library was pulled from use inside HELICS. HELICS is released with a BSD-3-Clause license.
+
+### [Catch2](https://github.com/catchorg/Catch2)
+The Catch2 test framework is used for tests. Catch2 is released under the Boost Software License 1.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,61 @@
+This material was prepared as an account of work sponsored by an agency of the United States Government. Neither the United States Government nor the United States Department of Energy, nor any copyright owner listed below, nor any of their employees, nor any jurisdiction or organization that has cooperated in the development of these materials, makes any warranty, express or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness or any information, apparatus, product, software, or process disclosed, or represents that its use would not infringe privately owned rights.
+Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States Government or any agency thereof, or copyright owner. The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States Government or any agency thereof.
+Copyright Owners:
+Battelle Memorial Institute;
+Lawrence Livermore National Security, LLC;
+Alliance for Sustainable Energy, LLC
+
+
+Open Source Disclaimer:
+This material was prepared as an account of work sponsored by an agency of the United States Government.  Neither the United States Government nor the United States Department of Energy, nor Battelle, nor any of their employees, nor any jurisdiction or organization that has cooperated in the development of these materials, makes any warranty, express or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness or any information, apparatus, product, software, or process disclosed, or represents that its use would not infringe privately owned rights.
+Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States Government or any agency thereof, or Battelle Memorial Institute. The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States Government or any agency thereof.
+
+PACIFIC NORTHWEST NATIONAL LABORATORY operated by BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY under Contract DE-AC05-76RL01830
+
+Attribution:
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
+
+GU Acknowledgement:
+These data were produced by BATTELLE under Contract No. DE AC05-76RL01830 with the U.S. Department of Energy (DOE).  For a five-year period from October 31, 2014, the U.S. Government is granted for itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license in this data to reproduce, prepare derivative works, and perform publicly and display publicly, by or on behalf of the U.S. Government.  There is provision for the possible extension of the term of this license.  Subsequent to that period or any extension granted, the U.S. Government is granted for itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license in this data to reproduce, prepare derivative works, distribute copies to the public, perform publicly and display publicly, and to permit others to do so.  The specific term of the license can be identified by inquiry made to BATTELLE or DOE.  Neither the United States nor DOE, nor any of their employees, makes any warranty, express or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any data, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights.
+
+Disclaimer:
+This Agreement is entered into by BATTELLE in its private capacity.  It is understood and agreed that the U.S. Government is not a party to this Agreement and in no manner whatsoever shall be liable for nor assume any responsibility or obligation for any claim, cost or damages arising out of or resulting from this Agreement or the subject matter licensed.
+
+LICENSEE recognizes that the Licensed Software is provided by BATTELLE on an as-is basis.  Nothing in this Agreement shall be deemed to be a representation or warranty by BATTELLE, or the U.S. Government, of the accuracy, safety or usefulness for any purpose, of the Licensed Software at any time made available by BATTELLE.  Neither the U.S. Government nor BATTELLE nor any affiliated company of BATTELLE shall have any liability whatsoever to LICENSEE or any other person for or on account of any injury, loss, or damage, of any kind or nature sustained by, or any damage assessed or asserted against, or any other liability incurred by or imposed upon LICENSEE or any other person, arising out of or in connection with or resulting from (i) the production, use or sale of the Licensed Software or any apparatus or product, or process; (ii) the use of any technical information, techniques, or practices disclosed by BATTELLE; or (iii) any advertising or other promotional activities with respect to any of the foregoing, and LICENSEE shall hold the U.S. Government, BATTELLE, and any affiliated company of BATTELLE, harmless in the event the U.S. Government, BATTELLE, or any affiliated company of BATTELLE, is held liable.  In the event BATTELLE is determined to be liable to LICENSEE for any reason arising out of this Agreement, despite the above limitation, the maximum extent of BATTELLE's liability shall be the license fee.
+
+BATTELLE represents that it has the right to grant all of the rights granted herein, except as to such rights as the Government of the United States of America may have or may assert.
+
+Enduser Terms:
+This Agreement is entered into by BATTELLE in its private capacity.  It is understood and agreed that the U.S. Government is not a party to this Agreement and in no manner whatsoever shall be liable for nor assume any responsibility or obligation for any claim, cost or damages arising out of or resulting from this Agreement or the subject matter licensed.
+
+LICENSEE recognizes that the Licensed Software is provided by BATTELLE on an as-is basis.  Nothing in this Agreement shall be deemed to be a representation or warranty by BATTELLE, or the U.S. Government, of the accuracy, safety or usefulness for any purpose, of the Licensed Software at any time made available by BATTELLE.  Neither the U.S. Government nor BATTELLE nor any affiliated company of BATTELLE shall have any liability whatsoever to LICENSEE or any other person for or on account of any injury, loss, or damage, of any kind or nature sustained by, or any damage assessed or asserted against, or any other liability incurred by or imposed upon LICENSEE or any other person, arising out of or in connection with or resulting from (i) the production, use or sale of the Licensed Software or any apparatus or product, or process; (ii) the use of any technical information, techniques, or practices disclosed by BATTELLE; or (iii) any advertising or other promotional activities with respect to any of the foregoing, and LICENSEE shall hold the U.S. Government, BATTELLE, and any affiliated company of BATTELLE, harmless in the event the U.S. Government, BATTELLE, or any affiliated company of BATTELLE, is held liable.  In the event BATTELLE is determined to be liable to LICENSEE for any reason arising out of this Agreement, despite the above limitation, the maximum extent of BATTELLE's liability shall be the license fee.
+
+BATTELLE represents that it has the right to grant all of the rights granted herein, except as to such rights as the Government of the United States of America may have or may assert.
+
+LLNL NOTICE
+
+portions of the code written by LLNL with release number
+LLNL-CODE-739319
+OCEC-17-164
+
+Portions of this work were produced under the auspices of the U.S. Department of
+Energy by Lawrence Livermore National Laboratory under Contract
+DE-AC52-07NA27344.
+
+This work was prepared as an account of work sponsored by an agency of
+the United States Government. Neither the United States Government nor
+Lawrence Livermore National Security, LLC, nor any of their employees
+makes any warranty, expressed or implied, or assumes any legal liability
+or responsibility for the accuracy, completeness, or usefulness of any
+information, apparatus, product, or process disclosed, or represents that
+its use would not infringe privately owned rights.
+
+Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the
+United States Government or Lawrence Livermore National Security, LLC.
+
+The views and opinions of authors expressed herein do not necessarily
+state or reflect those of the United States Government or Lawrence
+Livermore National Security, LLC, and shall not be used for advertising
+or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ Linux (Alpine)  | ARM/AArch64   | [![Build Status](https://cloud.drone.io/api/ba
 Linux (Ubuntu)  | x86_64        | [![Build Status](https://dev.azure.com/HELICS-test/netif/_apis/build/status/GMLC-TDC.netif?branchName=master)](https://dev.azure.com/HELICS-test/netif/_build/latest?definitionId=1&branchName=master)
 macOS 10.14     | x86_64        | [![Build Status](https://dev.azure.com/HELICS-test/netif/_apis/build/status/GMLC-TDC.netif?branchName=master)](https://dev.azure.com/HELICS-test/netif/_build/latest?definitionId=1&branchName=master)
 Windows 10      | x86_64        | [![Build Status](https://dev.azure.com/HELICS-test/netif/_apis/build/status/GMLC-TDC.netif?branchName=master)](https://dev.azure.com/HELICS-test/netif/_build/latest?definitionId=1&branchName=master)
+
+
+## Release
+NetIF is distributed under the terms of the BSD-3 clause license. All new
+contributions must be made under this license. [LICENSE](LICENSE)
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Portions of the code written by LLNL with release number LLNL-CODE-739319

--- a/gmlc/netif/NetIF.hpp
+++ b/gmlc/netif/NetIF.hpp
@@ -1,8 +1,8 @@
 /*
 Copyright (c) 2019,
-Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
-for Sustainable Energy, LLC.  See the top-level NOTICE for additional details.
-All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.
+See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #pragma once

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Copyright (c) 2019, Battelle Memorial Institute; Lawrence Livermore
+# National Security, LLC; Alliance for Sustainable Energy, LLC.
+# See the top-level NOTICE for additional details.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 add_executable(GetAddressTests GetAddressTests.cpp)
 target_link_libraries(GetAddressTests NetIF::NetIF)
 

--- a/tests/GetAddressTests.cpp
+++ b/tests/GetAddressTests.cpp
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.
+See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 


### PR DESCRIPTION
- Updates the license and copyright notices to meet the HELICS licensing plan.
- Add contributing, PR/Issue templates, and Code of Conduct to meet open source community standards: https://github.com/GMLC-TDC/netif/community