### PR TITLE
fix: remove arm32 pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,32 +1,4 @@
 kind: pipeline
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-  - name: submodules
-    image: alpine:3.12
-    commands:
-      # for updating submodules to latest upstream, add --remote
-      - apk add --no-cache git
-      - git submodule update --init --recursive
-
-  - name: build
-    image: alpine:3.12
-    failure: ignore
-    commands:
-      - apk update
-      - apk add --no-cache build-base cmake ninja
-      - mkdir -p build && cd build
-      - cmake -DENABLE_NETIF_TESTS=ON ..
-      - make
-      - ctest --verbose
-      - ifconfig
-
----
-kind: pipeline
 name: arm64
 
 platform:


### PR DESCRIPTION
### Summary

.drone.yml had two pipelines, one for arm32 and one for arm64. Existing build machines no longer support arm32 and has been removed so the pipeline does not hang.

If merged this pull request will no longer run the drone pipeline for arm32. 

This fixes issue #20

### Proposed changes

Entire section regarding ARM32  being removed
