### PR TITLE
Update Cirrus CI FreeBSD job to 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-14-0
 
 task:
   install_script: pkg install -y cmake


### PR DESCRIPTION
Cirrus CI appears to no longer have a FreeBSD 12.1 image; update the image to FreeBSD 14.0 for the CI job.