### PR TITLE
Fix codespell issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+        args: ["--skip=.github/CODE_OF_CONDUCT.md"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.5
     hooks:


### PR DESCRIPTION
The pre-commit autoupdate is failing due to a new word in their dictionary... due to a use of the british spelling of socioeconomic with a hyphen. It only affects the code of conduct file, which we use a standard one, so just skip spell checking that file.